### PR TITLE
dreambox-dvb-modules: Fix package-split

### DIFF
--- a/recipes-bsp/drivers/dreambox-dvb-modules-dm8000_3.2-20140604a.bb
+++ b/recipes-bsp/drivers/dreambox-dvb-modules-dm8000_3.2-20140604a.bb
@@ -40,3 +40,5 @@ DRIVERDATE = "${@'${PV}'.split('-')[-1]}"
 FILESEXTRAPATHS:prepend := "${THISDIR}/dreambox-dvb-modules:"
 
 FILES:${PN} += "${sysconfdir}/modules-load.d/${PN}.conf /lib/modules/${DM_LOCALVERSION}/extra"
+
+INHIBIT_PACKAGE_DEBUG_SPLIT = "1"


### PR DESCRIPTION
ERROR: dreambox-dvb-modules-dm8000-3.2-20140604a-r7.0 do_package_qa: QA Issue: non debug package contains .debug directory: dreambox-dvb-modules-dm8000 path /work/dm8000-oe-linux/dreambox-dvb-modules-dm8000/3.2-20140604a-r7.0/packages-split/dreambox-dvb-modules-dm8000/lib/modules/3.2-dm8000/extra/.debug/tu1216.ko