### PR TITLE
Do net set LOCALVERSION to fix build

### DIFF
--- a/recipes-bsp/linux/linux-dreambox.inc
+++ b/recipes-bsp/linux/linux-dreambox.inc
@@ -102,9 +102,6 @@ CMDLINE_UBI = "ubi.mtd=root root=ubi0:rootfs rootfstype=ubifs rw ${CMDLINE_CONSO
 CMDLINE = "${CMDLINE_UBI}"
 USB_CMDLINE = "root=${USB_ROOT} rootdelay=10 rw ${CMDLINE_CONSOLE}"
 
-LOCALVERSION = "-${MACHINE}"
-
-
 do_configure:prepend() {
 
         echo "" > ${S}/.config
@@ -119,9 +116,9 @@ do_configure:prepend() {
             -e '/CONFIG_LOGO_LINUX_CLUT224=/d' \
             -e '/CONFIG_LOCALVERSION/d' \
             -e '/CONFIG_LOCALVERSION_AUTO/d' \
-	    < '${WORKDIR}/defconfig' >>'${S}/.config'
+        < '${WORKDIR}/defconfig' >>'${S}/.config'
 
-        echo 'CONFIG_LOCALVERSION="${LOCALVERSION}"' >>${S}/.config
+        echo 'CONFIG_LOCALVERSION="-${MACHINE}"' >>${S}/.config
         echo '# CONFIG_LOCALVERSION_AUTO is not set' >>${S}/.config
 
 }


### PR DESCRIPTION
Error:
 package packagegroup-core-boot-1.0-r17.dm8000 requires dreambox-dvb-modules-dm8000, but none of the providers can be installed
 *   - conflicting requests
 *   - nothing provides kernel-3.2-dm8000 needed by dreambox-dvb-modules-dm8000-3.2-20140604a-r7.0.dm8000

Also warning:
WARNING: linux-dreambox-3.2-r14.20.93 do_package: QA Issue: linux-dreambox: Files/directories were installed but not shipped in any package:
  /boot/vmlinux-3.2-dm8000-dm8000.gz
Please set FILES such that these items are packaged. Alternatively if they are unneeded, avoid installing them or delete them within do_install.

Introduced with commit:
https://git.openembedded.org/openembedded-core/commit/?h=kirkstone&id=74897e505db19a23a5b864a48a4fa97d657605c8

With LOCALVERSION set to machine name, machine name will end up twice in module packaging.

-Replace tab with spaces(cosmetic).